### PR TITLE
Take out bonus vowels for round vowels bug fix

### DIFF
--- a/Player.js
+++ b/Player.js
@@ -10,6 +10,7 @@ class Player {
 
   updatePlayerScore(wheelValue, array) {
     var total = wheelValue * array.length
+
     this.score = this.score += total;
   }
 

--- a/Puzzle.js
+++ b/Puzzle.js
@@ -70,7 +70,6 @@ class Puzzle {
 
   checkGuessedLettersArray() {
     let currentPlayer = game.players[round.currPlayer];
-
     if (this.guessedLetters.length > 0) {
       currentPlayer.updatePlayerScore(wheel.currWheelValue, this.guessedLetters);
       domUpdates.displayScore(currentPlayer.score);

--- a/domUpdates.js
+++ b/domUpdates.js
@@ -69,7 +69,8 @@ const domUpdates = {
          OR SOLVE THE PUZZLE</span>`;
     } else {
       gamePrompt.innerHTML =
-        `WRONG! <span class='player-prompt'>
+        `<span>WRONG!</span>
+         <span class='player-prompt'>
         NEXT PLAYER... </span>
         <span>SPIN, BUY A VOWEL, OR SOLVE
          THE PUZZLE</span>`;

--- a/index.html
+++ b/index.html
@@ -119,13 +119,13 @@
     <p class='category-display'>blank</p>
   </section>
   <section class="letters-and-game-buttons">
-    <div class="vowels bonus-vowels">
+<!--     <div class="vowels bonus-vowels">
         <p class="letters vowel" id="AB">A</p>
         <p class="letters vowel" id="EB">E</p>
         <p class="letters vowel" id="IB">I</p>
         <p class="letters vowel" id="OB">O</p>
         <p class="letters vowel" id="UB">U</p>
-    </div>  
+    </div>  --> 
     <div class="letter-bank avoid-clicks round-letters">
       <p class="letters consonant" id="B">B</p>
       <p class="letters consonant" id="C">C</p>

--- a/script.js
+++ b/script.js
@@ -50,6 +50,6 @@ newGameButton.addEventListener('click', domUpdates.newGame);
 
 keepPlaying.addEventListener('click', domUpdates.hideWonRound);
 
-bonusVowels.addEventListener('click', domUpdates);
+
 
 


### PR DESCRIPTION
the event listener for the vowels was firing on the bonus vowels, so the correctly guessed vowel was not displayed. commented out the bonus vowels so we can work on them for the bonus round